### PR TITLE
Feature: Ability to have any number of datatable per page

### DIFF
--- a/resources/js/components/datatable/index.tsx
+++ b/resources/js/components/datatable/index.tsx
@@ -12,12 +12,13 @@ import {
   FormattedData,
   PendingAction,
   ConfirmDialogContent,
-  Column
+  Column,
+  PageProps
 } from './types';
 
-const Datatable: React.FC<DatatableProps> = ({ route: routeName, icons = {} }) => {
+const Datatable: React.FC<DatatableProps> = ({ route: routeName, name: name, icons = {} }) => {
 
-  const { columns, filters, actions, currentFilters, data, pageSize, availablePageSizes, sort, direction, translations, actionResult, visibleColumns: propsVisibleColumns, exportable = true, exportType = 'csv', exportColumn = 'visible' } = usePage().props;
+  const { columns, filters, actions, currentFilters, data, pageSize, availablePageSizes, sort, direction, translations, actionResult, visibleColumns: propsVisibleColumns, exportable = true, exportType = 'csv', exportColumn = 'visible' } = usePage().props[name] as PageProps;
 
   // Get translation function
   const { t } = useTranslation();
@@ -275,14 +276,16 @@ const Datatable: React.FC<DatatableProps> = ({ route: routeName, icons = {} }) =
 
       // Store current selectedRows before making the request
       const currentSelectedRows = [...selectedRows];
+      const payload: Record<string, unknown> = {};
+      payload[name] = queryParams;
 
       router.visit(url, {
         method: 'post',
-        data: queryParams,
+        data: payload,
         preserveState: true,
         preserveScroll: true,
         replace: true,
-        only: ['data', 'currentFilters', 'sort', 'direction', 'pageSize', 'visibleColumns'],
+        only: [name + '.data', name + '.currentFilters', name + '.sort', name + '.direction', name + '.pageSize',name + '.visibleColumns', name + '.availablePageSizes', name + '.columns', name + '.filters', name + '.actions'],
         onSuccess: () => {
           // After data is loaded, update selectedRows to only include IDs that still exist in the new data
           const checkboxColumn = columns.find(col => col.type === 'checkbox');

--- a/resources/js/components/datatable/types.ts
+++ b/resources/js/components/datatable/types.ts
@@ -120,5 +120,6 @@ export interface PageProps {
 
 export interface DatatableProps {
   route?: string;
+  name: string;
   icons?: Record<string, React.ComponentType<React.SVGProps<SVGSVGElement>>>;
 }

--- a/tests/Traits/WithDatatableRequest.php
+++ b/tests/Traits/WithDatatableRequest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Traits;
+
+trait WithDatatableRequest
+{
+    /**
+     * Helper method to set the request data correctly for the datatable
+     */
+    protected function setDatatableRequest(array $data): void
+    {
+        request()->replace(['dt' => $data]);
+    }
+}

--- a/tests/Unit/InertiaDatatableExportTest.php
+++ b/tests/Unit/InertiaDatatableExportTest.php
@@ -53,7 +53,7 @@ class InertiaDatatableExportTest extends TestCase
         $datatable->table($table);
 
         // Make a request with the export parameter
-        $request = new Request(['export' => true]);
+        $request = new Request(['dt' => ['export' => true]]);
         $this->app->instance(Request::class, $request);
 
         // Call render which should trigger handleExport
@@ -77,7 +77,7 @@ class InertiaDatatableExportTest extends TestCase
         $datatable->table($table);
 
         // Make a request with the export parameter
-        $request = new Request(['export' => true]);
+        $request = new Request(['dt' => ['export' => true]]);
         $this->app->instance(Request::class, $request);
 
         // Expect an abort with 403

--- a/tests/Unit/InertiaDatatableHandleExportTest.php
+++ b/tests/Unit/InertiaDatatableHandleExportTest.php
@@ -69,7 +69,7 @@ class InertiaDatatableHandleExportTest extends TestCase
         $datatable->table($table);
 
         // Make a request with the export parameter
-        $request = new Request(['export' => true]);
+        $request = new Request(['dt' => ['export' => true]]);
         $this->app->instance(Request::class, $request);
 
         // Call render which should trigger handleExport
@@ -93,7 +93,7 @@ class InertiaDatatableHandleExportTest extends TestCase
         $datatable->table($table);
 
         // Make a request with the export parameter
-        $request = new Request(['export' => true]);
+        $request = new Request(['dt' => ['export' => true]]);
         $this->app->instance(Request::class, $request);
 
         // Expect an abort with 403
@@ -137,11 +137,13 @@ class InertiaDatatableHandleExportTest extends TestCase
 
         // Create a request with export parameters
         $request = new Request([
-            'export' => true,
-            'exportType' => 'excel',
-            'exportColumns' => 'visible',
-            'exportRows' => 'selected',
-            'selectedIds' => '1,2,3'
+            'dt' => [
+                'export' => true,
+                'exportType' => 'excel',
+                'exportColumns' => 'visible',
+                'exportRows' => 'selected',
+                'selectedIds' => '1,2,3'
+            ]
         ]);
         $this->app->instance(Request::class, $request);
 
@@ -191,11 +193,13 @@ class InertiaDatatableHandleExportTest extends TestCase
 
         // Create a request with export parameters
         $request = new Request([
-            'export' => true,
-            'exportType' => 'excel',
-            'exportColumns' => 'visible',
-            'exportRows' => 'selected',
-            'selectedIds' => '1,2,3'
+            'dt' => [
+                'export' => true,
+                'exportType' => 'excel',
+                'exportColumns' => 'visible',
+                'exportRows' => 'selected',
+                'selectedIds' => '1,2,3'
+            ]
         ]);
         $this->app->instance(Request::class, $request);
 

--- a/tests/Unit/RelationshipColumnTest.php
+++ b/tests/Unit/RelationshipColumnTest.php
@@ -8,13 +8,14 @@ use Tests\TestModels\User;
 use Tests\TestModels\Team;
 use Tests\TestModels\WithTestModels;
 use Tests\TestModels\TestModelDataTable;
+use Tests\Traits\WithDatatableRequest;
 use Arkhas\InertiaDatatable\EloquentTable;
 use Arkhas\InertiaDatatable\Columns\Column;
 use Illuminate\Http\Request;
 
 class RelationshipColumnTest extends TestCase
 {
-    use WithTestModels;
+    use WithTestModels, WithDatatableRequest;
 
     protected function setUp(): void
     {
@@ -91,7 +92,7 @@ class RelationshipColumnTest extends TestCase
         $datatable->table($table);
 
         // Search for John Doe (user name)
-        request()->replace(['search' => 'John']);
+        $this->setDatatableRequest(['search' => 'John']);
         $results = $datatable->getResults()->get();
 
         // Should find at least one result
@@ -119,7 +120,7 @@ class RelationshipColumnTest extends TestCase
         $datatable->table($table);
 
         // Search for Engineering team
-        request()->replace(['search' => 'Engineering']);
+        $this->setDatatableRequest(['search' => 'Engineering']);
         $results = $datatable->getResults()->get();
 
         // Should find the test models assigned to people in the Engineering team
@@ -138,7 +139,7 @@ class RelationshipColumnTest extends TestCase
         $datatable->table($table);
 
         // Order by user name ascending
-        request()->replace(['sort' => 'user.name', 'direction' => 'asc']);
+        $this->setDatatableRequest(['sort' => 'user.name', 'direction' => 'asc']);
         $results = $datatable->getResults()->get();
 
         // Verify that we have all expected models in the results
@@ -165,7 +166,7 @@ class RelationshipColumnTest extends TestCase
         $datatable->table($table);
 
         // Order by team name ascending
-        request()->replace(['sort' => 'user.team.name', 'direction' => 'asc']);
+        $this->setDatatableRequest(['sort' => 'user.team.name', 'direction' => 'asc']);
         $results = $datatable->getResults()->get();
 
         // Get the team names for each result

--- a/tests/Unit/SessionMethodsTest.php
+++ b/tests/Unit/SessionMethodsTest.php
@@ -6,13 +6,14 @@ use Tests\TestCase;
 use Tests\TestModels\TestModelDataTable;
 use Tests\TestModels\TestModel;
 use Tests\TestModels\WithTestModels;
+use Tests\Traits\WithDatatableRequest;
 use Arkhas\InertiaDatatable\EloquentTable;
 use Arkhas\InertiaDatatable\Columns\Column;
 use Illuminate\Support\Facades\Session;
 
 class SessionMethodsTest extends TestCase
 {
-    use WithTestModels;
+    use WithTestModels, WithDatatableRequest;
 
     protected function setUp(): void
     {
@@ -30,14 +31,14 @@ class SessionMethodsTest extends TestCase
         $datatable->table($table);
 
         // Set page size in request
-        request()->replace(['pageSize' => 10]);
+        $this->setDatatableRequest(['pageSize' => 10]);
 
         // Get props to store in session
         $props1 = $datatable->getProps();
         $this->assertEquals(10, $props1['pageSize']());
 
         // Clear request and get props again
-        request()->replace([]);
+        $this->setDatatableRequest([]);
         $props2 = $datatable->getProps();
 
         // Page size should be retrieved from session
@@ -54,18 +55,19 @@ class SessionMethodsTest extends TestCase
         $datatable->table($table);
 
         // Set sort and direction in request
-        request()->replace([
+        $this->setDatatableRequest([
             'sort' => 'name',
             'direction' => 'desc'
         ]);
 
         // Get props to store in session
         $props1 = $datatable->getProps();
+
         $this->assertEquals('name', $props1['sort']());
         $this->assertEquals('desc', $props1['direction']());
 
         // Clear request and get props again
-        request()->replace([]);
+        $this->setDatatableRequest([]);
         $props2 = $datatable->getProps();
 
         // Sort and direction should be retrieved from session
@@ -83,7 +85,7 @@ class SessionMethodsTest extends TestCase
         $datatable->table($table);
 
         // Set filters in request
-        request()->replace([
+        $this->setDatatableRequest([
             'filters' => ['status' => 'active']
         ]);
 
@@ -92,7 +94,7 @@ class SessionMethodsTest extends TestCase
         $this->assertEquals(['status' => 'active'], $props1['currentFilters']());
 
         // Clear request and get props again
-        request()->replace([]);
+        $this->setDatatableRequest([]);
         $props2 = $datatable->getProps();
 
         // Filters should be retrieved from session
@@ -110,7 +112,7 @@ class SessionMethodsTest extends TestCase
         $datatable->table($table);
 
         // Set visible columns in request
-        request()->replace([
+        $this->setDatatableRequest([
             'visibleColumns' => ['name']
         ]);
 
@@ -119,7 +121,7 @@ class SessionMethodsTest extends TestCase
         $this->assertEquals(['name'], $props1['visibleColumns']());
 
         // Clear request and get props again
-        request()->replace([]);
+        $this->setDatatableRequest([]);
         $props2 = $datatable->getProps();
 
         // Visible columns should be retrieved from session
@@ -136,7 +138,7 @@ class SessionMethodsTest extends TestCase
         $datatable->table($table);
 
         // Set filters in request
-        request()->replace([
+        $this->setDatatableRequest([
             'filters' => ['status' => 'active']
         ]);
 
@@ -144,7 +146,7 @@ class SessionMethodsTest extends TestCase
         $datatable->getProps();
 
         // Now set empty filters
-        request()->replace([
+        $this->setDatatableRequest([
             'filters' => []
         ]);
 
@@ -200,7 +202,7 @@ class SessionMethodsTest extends TestCase
         $datatable->table($table);
 
         // Set search in request
-        request()->replace([
+        $this->setDatatableRequest([
             'search' => 'Alice'
         ]);
 
@@ -212,7 +214,7 @@ class SessionMethodsTest extends TestCase
         $this->assertEquals('Alice', $results1->first()->name);
 
         // Now set empty search
-        request()->replace([
+        $this->setDatatableRequest([
             'search' => ''
         ]);
 
@@ -241,7 +243,7 @@ class SessionMethodsTest extends TestCase
         $datatable->table($table);
 
         // Set page size in request
-        request()->replace([
+        $this->setDatatableRequest([
             'pageSize' => 2
         ]);
 
@@ -249,7 +251,7 @@ class SessionMethodsTest extends TestCase
         $datatable->getProps();
 
         // Clear request and get data
-        request()->replace([]);
+        $this->setDatatableRequest([]);
         $data = $datatable->getData();
 
         // Page size should be retrieved from session


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled support for multiple independent datatable instances on the same page by introducing a required name property for each datatable.
- **Bug Fixes**
  - Improved isolation of datatable state and server interactions to prevent conflicts between multiple tables.
- **Tests**
  - Updated and expanded test coverage to support the new request structure and multi-datatable functionality.
  - Added a helper trait for more consistent test setup.
- **Refactor**
  - Standardised request payload structure and state management for datatables.
  - Streamlined test code by introducing a reusable trait for request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->